### PR TITLE
HC-522-update: Updates to support moving away from the OPS user in the Core containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ADD https://api.github.com/repos/${ORG}/puppet-metrics/git/refs/heads/${BRANCH} 
 
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
- && sudo chown ops:ops $HOME/.git_oauth_token \
+ && sudo chown root:root $HOME/.git_oauth_token \
  && set -ex \
  && sudo dnf update -y \
  && sudo curl -skL ${GIT_URL} > /tmp/install.sh \
@@ -61,15 +61,15 @@ RUN set -ex \
  && sudo rm -rf /var/cache/dnf
 
 # copy ops home
-COPY --chown=ops:ops --from=0 /home/ops /home/ops
+COPY --chown=root:root --from=0 /home/ops /home/ops
 
 # link configs
 RUN set -ex \
  && ln -sf /home/ops/metrics/etc/celeryconfig.py /home/ops/metrics/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
-COPY --chown=ops:ops docker/supervisord.conf /home/ops/metrics/etc/supervisord.conf
-COPY --chown=ops:ops docker/conf.d /home/ops/metrics/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf /home/ops/metrics/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d /home/ops/metrics/etc/conf.d
 
 # set entrypoint
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=latest
+ARG TAG=HC-522
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-metrics/git/refs/heads/${BRANCH} version.json
 
+# set HOME explicitly
+ENV HOME /home/ops
+
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522-update
+ARG TAG=latest
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,6 @@ ARG HYSDS_RELEASE=develop
 # add latest repo version to invalidate cache
 ADD https://api.github.com/repos/${ORG}/puppet-metrics/git/refs/heads/${BRANCH} version.json
 
-# set HOME explicitly
-ENV HOME /home/ops
-
 # provision via puppet
 RUN --mount=type=secret,id=git_oauth_token sudo cp /run/secrets/git_oauth_token $HOME/.git_oauth_token \
  && sudo chown ops:ops $HOME/.git_oauth_token \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,15 +61,15 @@ RUN set -ex \
  && sudo rm -rf /var/cache/dnf
 
 # copy ops home
-COPY --chown=root:root --from=0 /home/ops /home/ops
+COPY --chown=root:root --from=0 /root /root
 
 # link configs
 RUN set -ex \
- && ln -sf /home/ops/metrics/etc/celeryconfig.py /home/ops/metrics/ops/hysds/celeryconfig.py
+ && ln -sf $HOME/metrics/etc/celeryconfig.py $HOME/metrics/ops/hysds/celeryconfig.py
 
 # set default supervisord conf and copy includes
-COPY --chown=root:root docker/supervisord.conf /home/ops/metrics/etc/supervisord.conf
-COPY --chown=root:root docker/conf.d /home/ops/metrics/etc/conf.d
+COPY --chown=root:root docker/supervisord.conf $HOME/metrics/etc/supervisord.conf
+COPY --chown=root:root docker/conf.d $HOME/metrics/etc/conf.d
 
 # set entrypoint
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental
-ARG TAG=HC-522
+ARG TAG=HC-522-update
 FROM hysds/dev:${TAG}
 
 # get org and branch

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # set HOME explicitly
-export HOME=/home/ops
+export HOME=/root
 
 # wait for redis and ES
 /wait-for-it.sh -t 30 metrics-redis:6379
@@ -15,14 +15,14 @@ GID=$(id -g)
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
 # update user and group ids
-gosu 0:0 groupmod -g $GID ops 2>/dev/null
-gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-gosu 0:0 usermod -aG docker ops 2>/dev/null
+#gosu 0:0 groupmod -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -aG docker ops 2>/dev/null
 
 # update ownership
-gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
 
 # source bash profile
 source $HOME/.bash_profile

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,15 +14,9 @@ GID=$(id -g)
 # generate ssh keys
 gosu 0:0 ssh-keygen -A 2>/dev/null
 
-# update user and group ids
-#gosu 0:0 groupmod -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -aG docker ops 2>/dev/null
-
-# update ownership
-#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/log/supervisor 2>/dev/null || true
+if [ -e /var/run/docker.sock ]; then
+  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+fi
 
 # source bash profile
 source $HOME/.bash_profile

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class metrics inherits hysds_base {
   # copy user files
   #####################################################
   
-  file { "/home/$user/.bash_profile":
+  file { "/$user/.bash_profile":
     ensure  => present,
     content => template('metrics/bash_profile'),
     owner   => $user,
@@ -22,7 +22,7 @@ class metrics inherits hysds_base {
   # metrics directory
   #####################################################
 
-  $metrics_dir = "/home/$user/metrics"
+  $metrics_dir = "/$user/metrics"
 
 
   #####################################################
@@ -98,10 +98,10 @@ class metrics inherits hysds_base {
 
   #####################################################
   # install install_hysds.sh script and other config
-  # files in ops home
+  # files in root home
   #####################################################
 
-  file { "/home/$user/install_hysds.sh":
+  file { "/$user/install_hysds.sh":
     ensure  => present,
     content => template('metrics/install_hysds.sh'),
     owner   => $user,
@@ -163,7 +163,7 @@ class metrics inherits hysds_base {
 
 
   metrics::tarball { "logstash-7.9.3.tar.gz":
-    install_dir => "/home/$user",
+    install_dir => "/$user",
     owner => $user,
     group => $group,
     require => [
@@ -173,9 +173,9 @@ class metrics inherits hysds_base {
   }
 
 
-  file { "/home/$user/logstash":
+  file { "/$user/logstash":
     ensure => 'link',
-    target => "/home/$user/logstash-7.9.3",
+    target => "/$user/logstash-7.9.3",
     owner => $user,
     group => $group,
     require => Metrics::Tarball['logstash-7.9.3.tar.gz'],
@@ -188,7 +188,7 @@ class metrics inherits hysds_base {
     group   => $group,
     mode    => "0644",
     content => template('metrics/indexer.conf'),
-    require => File["/home/$user/logstash"],
+    require => File["/$user/logstash"],
   }
 
 
@@ -200,7 +200,7 @@ class metrics inherits hysds_base {
 
 
   metrics::tarball { "kibana-7.9.3-linux-x86_64.tar.gz":
-    install_dir => "/home/$user",
+    install_dir => "/$user",
     owner => $user,
     group => $group,
     require => [
@@ -210,22 +210,22 @@ class metrics inherits hysds_base {
   }
 
 
-  file { "/home/$user/kibana":
+  file { "/$user/kibana":
     ensure => 'link',
-    target => "/home/$user/kibana-7.9.3-linux-x86_64",
+    target => "/$user/kibana-7.9.3-linux-x86_64",
     owner => $user,
     group => $group,
     require => Metrics::Tarball["kibana-7.9.3-linux-x86_64.tar.gz"],
   }
 
 
-#  file { "/home/$user/kibana/config/kibana.yml":
+#  file { "/$user/kibana/config/kibana.yml":
 #    ensure  => present,
 #    owner   => $user,
 #    group   => $group,
 #    mode    => "0644",
 #    content => template('metrics/kibana.yml'),
-#    require => File["/home/$user/kibana"],
+#    require => File["/$user/kibana"],
 #  }
 
 


### PR DESCRIPTION
This PR updates the Dockerfile, entrypoint scripts, and Puppet Manifest files such that it supports the moving away from the OPS user that the Core containers would default to.


CircleCI passed when building containers under the HC-522-update tag:

![image](https://github.com/user-attachments/assets/2154a661-b3cb-4505-91e5-8506c4a28349)

Will need to remove the following kludges before merging:
- https://github.com/hysds/puppet-metrics/compare/docker...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR2